### PR TITLE
feat: add uri scheme for opening timer by opening a link

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="bodhi" android:host="timer" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".NNumberPicker"


### PR DESCRIPTION
for #15

@tzugen can you please take a look?

link scheme is like this: bodhi://timer?times=60,120 (will start a 1 minute and a two minute timer)

Pausing does not seem to work, but I think that is not necessary to support initially.