### PR TITLE
feat: add uri scheme for opening timer by opening a link

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -47,6 +47,12 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="bodhi" android:host="timer" />
+            </intent-filter>
         </activity>
         <activity
             android:name=".NNumberPicker"

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/TimerActivity.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/TimerActivity.kt
@@ -7,7 +7,12 @@
 
 package org.yuttadhammo.BodhiTimer
 
-import android.content.*
+import android.content.ActivityNotFoundException
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.SharedPreferences
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
@@ -48,7 +53,7 @@ import org.yuttadhammo.BodhiTimer.Util.Time.str2timeString
 import org.yuttadhammo.BodhiTimer.Util.Time.time2Array
 import org.yuttadhammo.BodhiTimer.Util.Time.time2humanStr
 import java.io.FileNotFoundException
-import java.util.*
+import java.util.Locale
 import kotlin.math.max
 import kotlin.math.roundToInt
 
@@ -113,7 +118,7 @@ class TimerActivity : AppCompatActivity(), View.OnClickListener, OnSharedPrefere
     private fun checkForDeepLink(intent: Intent?) {
         val data: Uri = intent?.data ?: return
 
-        val paramNames = data.getQueryParameterNames()
+        val paramNames = data.queryParameterNames
 
         if (paramNames.contains("times")) {
             val tL = TimerList()
@@ -130,7 +135,7 @@ class TimerActivity : AppCompatActivity(), View.OnClickListener, OnSharedPrefere
                 try {
                     time = Integer.parseInt(timeStr)
                 } catch (e: NumberFormatException) {
-                    Log.e(TAG, "Invalid number format provided: " + timeStr, e)
+                    Log.e(TAG, "Invalid number format provided: $timeStr", e)
                 }
 
                 if (time > 0) {

--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/TimerActivity.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/TimerActivity.kt
@@ -126,11 +126,21 @@ class TimerActivity : AppCompatActivity(), View.OnClickListener, OnSharedPrefere
             }
 
             for (timeStr in data.getQueryParameter("times")!!.split(",").toTypedArray()) {
-                val time = Integer.valueOf(timeStr)
-                tL.timers.add(TimerList.Timer(time * 1000, notificationUri, SessionTypes.REAL))
+                var time = 0
+                try {
+                    time = Integer.parseInt(timeStr)
+                } catch (e: NumberFormatException) {
+                    Log.e(TAG, "Invalid number format provided: " + timeStr, e)
+                }
+
+                if (time > 0) {
+                    tL.timers.add(TimerList.Timer(time * 1000, notificationUri, SessionTypes.REAL))
+                }
             }
 
-            mAlarmTaskManager?.startAlarms(tL)
+            if (tL.timers.size > 0) {
+                mAlarmTaskManager?.startAlarms(tL)
+            }
         }
     }
 


### PR DESCRIPTION
for #15

@tzugen can you please take a look? 

link scheme is like this: `bodhi://timer?times=60,120` (will start a 1 minute and a two minute timer)

Pausing does not work properly, but I think that is not necessary to support initially.