### PR TITLE
Make 'fullscreen' Setting always show/hide the system status bar

### DIFF
--- a/app/src/main/java/org/yuttadhammo/BodhiTimer/TimerActivity.kt
+++ b/app/src/main/java/org/yuttadhammo/BodhiTimer/TimerActivity.kt
@@ -303,7 +303,10 @@ class TimerActivity : AppCompatActivity(), View.OnClickListener, OnSharedPrefere
 
     private fun setLowProfile() {
         val rootView = window.decorView
-        rootView.systemUiVisibility = View.SYSTEM_UI_FLAG_LOW_PROFILE
+        if (Settings.fullscreen)
+            rootView.systemUiVisibility = View.SYSTEM_UI_FLAG_LOW_PROFILE
+        else
+            rootView.systemUiVisibility = View.SYSTEM_UI_FLAG_VISIBLE
     }
 
     private fun showNumberPicker() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,7 +58,7 @@
     <string name="bmp_or_circle">Animation Type</string>
     <string name="custom_bmp">Use Custom Image</string>
     <string name="fullscreen">Full Screen</string>
-    <string name="fullscreen_desc">Hide the status bar when timer is running.</string>
+    <string name="fullscreen_desc">Hide the status bar when app is running.</string>
     <string name="hide_time">Hide Time Left</string>
     <string name="hide_time_desc">Don\'t show time left.</string>
     <string name="misc">Misc</string>


### PR DESCRIPTION
I'm using BodhiTimer to keep track of time segments in group events.

For this use case, having the actual wall clock time easily visible is important to me.

Because `systemUiVisibility = SYSTEM_UI_FLAG_LOW_PROFILE` is always applied, most of the status bar (all but the battery icon on my phone) would be hidden whenever BodhiTimer is open.

I changed the logic so that this flag would also only be applied when the user actually enables the `FULLSCREEN` Setting.

I intend to make further additions:
  1. create a Setting to show wall clock times for the currently configured timer, ie "07:24 -> 07:29"
  2. have a look at getting the Do Not Disturb handling more stable (it's being a bit weird for me)
  3. create a Setting to choose a configurable grace period after BodhiTimer has expired, before releasing Do Not Disturb again

Before I do that: quite a few things are flagged as deprecated by my current Android Studio - all of the `FULLSCREEN` handling to begin with. Which is the lowest API Level you are intentionally targeting? Would "modernization" PRs be welcome, or should I rather try to leave all that as alone as possible?